### PR TITLE
Correct Sanshoku Doujun name

### DIFF
--- a/src/scripts/YakuConversion.js
+++ b/src/scripts/YakuConversion.js
@@ -24,7 +24,7 @@ const yakuList = [
   "Chiitoi",
   "Chanta",
   "Itsuu",
-  "Sanshokudoujin",
+  "Sanshoku Doujun",
   "Sanshoku Doukou",
   "Sankantsu",
   "Toitoi",


### PR DESCRIPTION
Change Yaku named "sanshokudoujin" to "Sanshoku Doujun"

Requested in #28 