### PR TITLE
Adding option to ignore Fu for limit hands

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -279,7 +279,7 @@ button {
 .checkAnswer:disabled {
   border-radius: 15px;
   font-size: 15px;
-  margin-right: 20px;
+  margin-right: 0px;
   background-color: #244c4c;
 }
 
@@ -335,6 +335,10 @@ input[type=number] {
 
 .wrongAnswer {
   color: red;
+}
+
+.ignoredAnswer {
+  color: gray;
 }
 
 .winRatePanel {

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import "./App.css";
 import "bootstrap/dist/css/bootstrap.min.css";
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { TilePanel } from "./components/TilePanel";
 import { InfoPanel } from "./components/InfoPanel";
 import { QuizPanel } from "./components/QuizPanel";
@@ -24,19 +24,23 @@ function App() {
     require("./data/" + jsonMetaData[num])
   );
   const [options, setOptions] = useState({
-    pointSticks: false,
     testHan: true,
     testFu: true,
     kiriageMangan: false,
     testHonba: false,
+    ignoreFuOnLimit: false,
   });
-
 
   const [answerVisible, setanswerVisible] = useState(false);
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const [correctAnswers, setCorrectAnswers] = useState(0);
   const [wrongAnswers, setWrongAnswers] = useState(0);
+  const [ignoreFuAnswer, setIgnoreFuAnswer] = useState(checkIgnoreFuAnswer(options, agari));
+
+  useEffect(() => {
+    setIgnoreFuAnswer(checkIgnoreFuAnswer(options, agari));
+  }, [agari, options]);
 
   const toggleOptions = (event) => {
     event.stopPropagation();
@@ -137,6 +141,7 @@ function App() {
         newHand={newHand}
         addCorrectAnswer={addCorrectAnswer}
         addWrongAnswer={addWrongAnswer}
+        ignoreFuAnswer={ignoreFuAnswer}
       />
       
       {/* <ScrollButton direction='down' watchedElement={quizPanel} />
@@ -156,6 +161,14 @@ function outputOptions() {
       option.children[0].children[0].checked;
   });
   return options;
+}
+
+function checkIgnoreFuAnswer(options, agari) {
+  if(options.ignoreFuOnLimit && agari.han > 4){
+    return true;
+  }else{
+    return false;
+  }
 }
 
 export default App;

--- a/src/components/OptionsMenu.js
+++ b/src/components/OptionsMenu.js
@@ -1,14 +1,14 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Collapse, Label, Input } from "reactstrap";
 
 
 function OptionsMenu(props) {
-  const options = props.options;
+  var options = props.options;
   const isOpen = props.menuOpen;
   const handName = props.handName;
   const onClickOutside = props.onClickOutside
-
-  // const [TooltipOpen, setTooltipOpen] = React.useState(false);
+  const [changesPending, setChangesPending] = useState(false);
+  const [checkboxes, setCheckboxes] = useState({...options});
 
   const ref = useRef(null);
 
@@ -26,6 +26,24 @@ function OptionsMenu(props) {
       };
   }, [onClickOutside]);
 
+  useEffect(() => {
+    // Check if the checkboxes object matches the options object
+    const areEqual = Object.keys(checkboxes).every(
+      (key) => checkboxes[key] === options[key]
+    );
+    setChangesPending(!areEqual);
+  }, [checkboxes, options]);
+
+  const handleCheckboxChange = (id) => {
+    // Update the state by toggling the checkbox with the corresponding id
+    setCheckboxes({
+      ...checkboxes,
+      [id]: !checkboxes[id],
+    });
+  };
+
+
+
 
   return (
 
@@ -39,6 +57,7 @@ function OptionsMenu(props) {
       optionText="Test Han"
       changeOptions={props.changeOptions}
       size="small"
+      handleCheckboxChange={handleCheckboxChange}
       />
       <MenuOption
       options={options}
@@ -46,6 +65,7 @@ function OptionsMenu(props) {
       optionText="Test Fu"
       changeOptions={props.changeOptions}
       size="small"
+      handleCheckboxChange={handleCheckboxChange}
       />
       <MenuOption
       options={options}
@@ -53,6 +73,7 @@ function OptionsMenu(props) {
       optionText="Kiriage Mangan Mode"
       changeOptions={props.changeOptions}
       size="small"
+      handleCheckboxChange={handleCheckboxChange}
       />
       <br />
       <MenuOption
@@ -61,6 +82,16 @@ function OptionsMenu(props) {
       optionText="Include Honba Sticks"
       changeOptions={props.changeOptions}
       size="small"
+      handleCheckboxChange={handleCheckboxChange}
+      />
+      <br />
+      <MenuOption
+      options={options}
+      optionId="ignoreFuOnLimit"
+      optionText="Ignore Fu on Limit Hands"
+      changeOptions={props.changeOptions}
+      size="small"
+      handleCheckboxChange={handleCheckboxChange}
       />
       <br />
       <div className="link" style={{marginTop:'10px' }}>
@@ -75,23 +106,15 @@ function OptionsMenu(props) {
       className="checkAnswer"
       id="applyButton"
       onClick={(e) => props.changeOptions(e)}
+      disabled={!changesPending}
       >
       Apply
       </button>
-      {/* <Tooltip
-      isOpen={TooltipOpen}
-      className="hanTooltip"
-      placement="right"
-      target="applyButton"
-      toggle={() => {
-      setTooltipOpen(!TooltipOpen);
-      }}
-      >
-      Applying these settings will refresh the hand
-      </Tooltip> */}
       </div>
       </Collapse>
     </div>
+
+    
    
   );
 }
@@ -107,6 +130,7 @@ function MenuOption(props) {
           id={props.optionId}
           defaultChecked={props.options[props.optionId]}
           key={props.optionId}
+          onChange={() => props.handleCheckboxChange(props.optionId)}
         />{" "}
         {props.optionText}
       </Label>

--- a/src/components/QuizPanel.js
+++ b/src/components/QuizPanel.js
@@ -33,12 +33,13 @@ function QuizPanel(props) {
     for (let i = 1; i < quizBox.length; i++) {
       const row = quizBox[i];
 
+      const label = row.querySelectorAll("label")[0];
       const input = row.querySelectorAll("input")[0];
       const output = row.querySelectorAll("strong")[0];
       const answer = rowMapping[output.id];
 
       output.textContent = answer;
-      output.className = getClassName(answer, input.value);
+      output.className = getClassName(answer, input.value, label.textContent, props.ignoreFuAnswer);
       input.disabled = true;
     }
 
@@ -70,7 +71,8 @@ function QuizPanel(props) {
             {generateHanAndFuQuiz(
               props.options.testHan,
               props.options.testFu,
-              agari
+              agari,
+              props.ignoreFuAnswer
             )}
             {generatePointsQuiz(
               isTsumo,
@@ -100,7 +102,11 @@ function QuizPanel(props) {
   );
 }
 
-function getClassName(agariValue, answerValue) {
+function getClassName(agariValue, answerValue, label, ignoreFuAnswer) {
+  // if we ignore Fu on limit hands, and it is a hand above 4 han, we want to ignore the Fu answer
+  if (label === "Fu" && ignoreFuAnswer) {
+    return "ignoredAnswer answerText unselectable";
+  }
   const stringAgari = agariValue.toString();
   const trimmedAnswer = answerValue.trim();
   if (stringAgari === trimmedAnswer) {
@@ -154,9 +160,12 @@ function GenerateRow(props) {
   return rowData;
 }
 
-function formatFuList(agari) {
+function formatFuList(agari, ignoreFuAnswer) {
   const output = [];
   output.push(<p></p>);
+  if (ignoreFuAnswer) {
+    output.push(<p style={{ color: "white" }}>Set to ignore Fu on limit hands</p>);
+  }
   agari.fu_details.forEach((line) => {
     var reason = capitalizeFirstLetter(line.reason.replaceAll("_", " "));
     var fuValue = line.fu;
@@ -176,7 +185,7 @@ function formatHanList(agari) {
   return output;
 }
 
-function generateHanAndFuQuiz(isHanQuiz, isFuQuiz, agari) {
+function generateHanAndFuQuiz(isHanQuiz, isFuQuiz, agari, ignoreFuAnswer) {
   const hanAndFuQuizRows = [];
 
   if (isHanQuiz) {
@@ -197,7 +206,7 @@ function generateHanAndFuQuiz(isHanQuiz, isFuQuiz, agari) {
         inputId="fuBox"
         outputId="fuAnswer"
         name="fu"
-        tooltipContent={formatFuList(agari)}
+        tooltipContent={formatFuList(agari, ignoreFuAnswer)}
       />
     );
   }

--- a/src/helpPages/scoring.md
+++ b/src/helpPages/scoring.md
@@ -4,6 +4,16 @@
 
 All hands on this site have been extracted from Tenhou game logs, so the rules used on this site use Tenhou's ruleset.
 
+## Site Options
+
+A brief overview of the different options on the site: 
+
+- `Test Han` - When disabled, you aren't required to calculate Han.
+- `Test Fu` - When disabled, you aren't required to calculate Fu.
+- `Kiriage Mangan Mode` - When enabled, a 4 han and 30 fu hand, as well as a 3 han 60 fu hand, are considered a mangan hand.
+- `Include Honba Sticks` - When enabled, an extra field will be added and you will need to calculate the total score including additional points from honba sticks.
+- `Ignore Fu on Limit Hands` - When enabled, if a hand has 5 or more han then you won't get penalised for an incorrect Fu answer.
+
 ## Calculating Han
 
 Han is the sum of the number of yaku (and their worth) added to the number of dora (ドラ) that are in your hand. 


### PR DESCRIPTION
Fixes #46 

- Added an option to ignore Fu calculation when Han is 5 or more, as Fu is not required in this scenario.
- Enhanced the Apply button in the options menu to provide better user feedback when changes are applied.
- Updated the site documentation to include a short guide on the new options feature.

